### PR TITLE
fix status bar in iOS using theme color #4839

### DIFF
--- a/Microsoft.PWABuilder.IOS.Web/Resources/ios-project-src/pwa-shell/ViewController.swift
+++ b/Microsoft.PWABuilder.IOS.Web/Resources/ios-project-src/pwa-shell/ViewController.swift
@@ -66,9 +66,12 @@ class ViewController: UIViewController, WKNavigationDelegate, UIDocumentInteract
         }
 
         if #available(iOS 15.0, *), adaptiveUIStyle {
-            themeObservation = PWAShell.webView.observe(\.underPageBackgroundColor) { [unowned self] webView, _ in
-                currentWebViewTheme = PWAShell.webView.underPageBackgroundColor.isLight() ?? true ? .light : .dark
+            themeObservation = PWAShell.webView.observe(\.themeColor) { [unowned self] webView, _ in
+                let backgroundColor = PWAShell.webView.underPageBackgroundColor;
+                let themeColor = PWAShell.webView.themeColor;
+                currentWebViewTheme = themeColor?.isLight() ?? backgroundColor?.isLight() ?? true ? .light : .dark
                 self.overrideUIStyle()
+                view.backgroundColor = themeColor ?? backgroundColor;
             }
         }
     }


### PR DESCRIPTION
## Fixes  
- pwa-builder/PWABuilder#4839

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the current behavior?

The color of the status bar is incorrect in some cases even though the manifest is set correctly

## Describe the new behavior?

It will use the theme color as preferred in case it exists so the status bar will be adapted to that theme.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
