### PR TITLE
Attempting to change the cache strategy when there is a network error #4831

### DIFF
--- a/Microsoft.PWABuilder.IOS.Web/Resources/ios-project-src/pwa-shell/ViewController.swift
+++ b/Microsoft.PWABuilder.IOS.Web/Resources/ios-project-src/pwa-shell/ViewController.swift
@@ -4,7 +4,11 @@ import WebKit
 var webView: WKWebView! = nil
 
 class ViewController: UIViewController, WKNavigationDelegate, UIDocumentInteractionControllerDelegate {
-    
+    enum LoadingMode {
+        case defaultCachePolicy
+        case forceCache
+    }
+
     var documentController: UIDocumentInteractionController?
     func documentInteractionControllerViewControllerForPreview(_ controller: UIDocumentInteractionController) -> UIViewController {
         return self
@@ -17,6 +21,7 @@ class ViewController: UIViewController, WKNavigationDelegate, UIDocumentInteract
     var toolbarView: UIToolbar!
     
     var htmlIsLoaded = false;
+    private var loadingMode = LoadingMode.defaultCachePolicy
     
     private var themeObservation: NSKeyValueObservation?
     var currentWebViewTheme: UIUserInterfaceStyle = .unspecified
@@ -124,8 +129,22 @@ class ViewController: UIViewController, WKNavigationDelegate, UIDocumentInteract
         webviewView.addSubview(toolbarView)
     }
     
-    @objc func loadRootUrl() {
-        PWAShell.webView.load(URLRequest(url: SceneDelegate.universalLinkToLaunch ?? SceneDelegate.shortcutLinkToLaunch ?? rootUrl))
+    @objc func loadRootUrl(cachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy) {
+        CloudpilotEmu.webView.load(URLRequest(url: SceneDelegate.universalLinkToLaunch ?? SceneDelegate.shortcutLinkToLaunch ?? rootUrl, cachePolicy: cachePolicy))
+    }
+    
+    func reloadWebview(
+        loadingMode: LoadingMode = LoadingMode.defaultCachePolicy
+    ) {
+        switch loadingMode {
+        case LoadingMode.defaultCachePolicy:
+            loadRootUrl(cachePolicy: .useProtocolCachePolicy);
+
+        case LoadingMode.forceCache:
+            loadRootUrl(cachePolicy: .useProtocolCachePolicy);
+        }
+
+        self.loadingMode = loadingMode
     }
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!){
@@ -147,19 +166,24 @@ class ViewController: UIViewController, WKNavigationDelegate, UIDocumentInteract
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         htmlIsLoaded = false;
         
-        if (error as NSError)._code != (-999) {
-            self.overrideUIStyle(toDefault: true);
+        if (error as NSError)._code == (-999) { return }
+        
+        self.overrideUIStyle(toDefault: true);
+        webView.isHidden = true;
+        loadingView.isHidden = false;
 
-            webView.isHidden = true;
-            loadingView.isHidden = false;
+        if loadingMode == LoadingMode.defaultCachePolicy {
+            DispatchQueue.main.async {
+                self.reloadWebview(loadingMode: LoadingMode.forceCache)
+            }
+        } else {
             animateConnectionProblem(true);
-            
             setProgress(0.05, true);
-
+            
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                 self.setProgress(0.1, true);
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                    self.loadRootUrl();
+                    self.reloadWebview()
                 }
             }
         }


### PR DESCRIPTION
## Fixes 
- pwa-builder/PWABuilder#4831

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the current behavior?
In airplane mode or when there are network problems, the WebView denies HTTP requests early on, as it has already identified connection problems instead of trying. This causes the service worker serving as a proxy between the cache and the request to not work properly.

## Describe the new behavior?
By changing the cache strategy in case of an error, this allows to try to resolve the page load if all resources are available beforehand.

Note: Rigorous testing was attempted to confirm this behavior. However, it could not be tested on a physical IPhone to confirm that it is as expected.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
